### PR TITLE
Workaround generated openapi java classes in target folder not detected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,9 @@
             <resource>
                 <directory>src/main/resources</directory>
             </resource>
+            <resource>
+                <directory>target/generated-sources/camel-quarkus-rest-openapi/src/main/java</directory>
+            </resource>
         </resources>
 
         <pluginManagement>


### PR DESCRIPTION
by VS code Maven